### PR TITLE
The user could log in with any of the configurations listed for api. …

### DIFF
--- a/config/api_change.json
+++ b/config/api_change.json
@@ -1,5 +1,8 @@
 {
-  "api" : "pass4api",
+  "api_users" : {
+      "api_read": "api_read_password",
+      "api_write": "api_write_password"
+  },
   "app_port" : "3443",
   "ssl_key": "FOR HTTPS OPTIONAL REMOVABLE VARIABLE (ex: ssl/node.key)",
   "ssl_cert": "FOR HTTPS OPTIONAL REMOVABLE VARIABLE (ex: ssl/node.pem)"

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -9,7 +9,7 @@ var configPath = require('../config/config.js').configPath;
 
 var ad = require('../'+ configPath + '/ad.json');
 var auth = require('../'+ configPath + '/auth.json');
-var apiUsers = require('../'+ configPath + '/api.json');
+var apiUsers = require('../'+ configPath + '/api.json').api_users;
 
 // Create CAS client
 var Client = null;


### PR DESCRIPTION
…For example if a user knew the app_port and 3443 the authentication would be successful.

The fix is also in the full pull request with all the new features added. To avoid merging issues - I recommend using the full pull request. 
