### PR TITLE
Pin mongo-express image to 0.54.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       retries: 5
       start_period: 10s
   mongo-express:
-    image: mongo-express
+    image: mongo-express:0.54.0
     restart: unless-stopped
     ports:
       - ${MONGO_EXPRESS_PORT-8081}:8081


### PR DESCRIPTION
This pull request was filed with antigravity.

**Motivation:**
Pins the `mongo-express` image to version `0.54.0` in the Docker Compose configuration. This resolves a compatibility issue with the latest `mongo-express` image release, ensuring the local Docker development environment starts up successfully.

cc @dongliu for review.